### PR TITLE
Avoid resetting the "TO" time when selecting a "FROM" time

### DIFF
--- a/lib/time_range.dart
+++ b/lib/time_range.dart
@@ -130,8 +130,12 @@ class _TimeRangeState extends State<TimeRange> {
     _startHour = hour;
     setState(() {});
     if (_endHour != null) {
-      _endHour = null;
-      widget.onRangeCompleted(null);
+      if(_endHour.inMinutes() <= _startHour.inMinutes()){
+        _endHour = null;
+        widget.onRangeCompleted(null);
+      } else {
+        widget.onRangeCompleted(TimeRangeResult(_startHour, _endHour));
+      }
     }
   }
 

--- a/lib/time_range.dart
+++ b/lib/time_range.dart
@@ -130,7 +130,7 @@ class _TimeRangeState extends State<TimeRange> {
     _startHour = hour;
     setState(() {});
     if (_endHour != null) {
-      if(_endHour.inMinutes() <= _startHour.inMinutes()){
+      if(_endHour.inMinutes() <= _startHour.inMinutes() && (_endHour.inMinutes() - _startHour.inMinutes()).remainder(widget.timeStep) == 0){
         _endHour = null;
         widget.onRangeCompleted(null);
       } else {


### PR DESCRIPTION
 * User does not need to select the "TO" time again after selecting the "FROM" time if the "FROM" time is before the "TO" time