### PR TITLE
Avoid asking user to select end time if not neccessary

### DIFF
--- a/lib/time_range.dart
+++ b/lib/time_range.dart
@@ -127,11 +127,14 @@ class _TimeRangeState extends State<TimeRange> {
   }
 
   void _startHourChanged(TimeOfDay hour) {
-    _startHour = hour;
-    setState(() {});
+    setState(() => _startHour = hour);
     if (_endHour != null) {
-      _endHour = null;
-      widget.onRangeCompleted(null);
+      if(_endHour.inMinutes() <= _startHour.inMinutes() || (_endHour.inMinutes() - _startHour.inMinutes()).remainder(widget.timeBlock) != 0){
+        _endHour = null;
+        widget.onRangeCompleted(null);
+      } else {
+        widget.onRangeCompleted(TimeRangeResult(_startHour, _endHour));
+      }
     }
   }
 


### PR DESCRIPTION
 * Takes into account the time user has selected and the time block before resetting the end time