### PR TITLE
Use devices time display format instead of hard coded one.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -99,13 +99,14 @@ class _HomePageState extends State<HomePage> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
                       Text(
-                        'Selected Range: ${_timeRange.start.hhmm()} - ${_timeRange.end.hhmm()}',
+                        'Selected Range: ${_timeRange.start.format(context)} - ${_timeRange.end.format(context)}',
                         style: TextStyle(fontSize: 20, color: dark),
                       ),
                       SizedBox(height: 20),
                       MaterialButton(
                         child: Text('Default'),
-                        onPressed: () => setState(() => _timeRange = _defaultTimeRange),
+                        onPressed: () =>
+                            setState(() => _timeRange = _defaultTimeRange),
                         color: orange,
                       )
                     ],

--- a/lib/time_list.dart
+++ b/lib/time_list.dart
@@ -42,7 +42,7 @@ class TimeList extends StatefulWidget {
 
 class _TimeListState extends State<TimeList> {
   final ScrollController _scrollController = ScrollController();
-  final double itemExtent = 85;
+  final double itemExtent = 90;
   TimeOfDay _selectedHour;
   List<TimeOfDay> hours = [];
 
@@ -90,6 +90,7 @@ class _TimeListState extends State<TimeList> {
         scrollDirection: Axis.horizontal,
         padding: EdgeInsets.only(left: widget.padding),
         itemCount: hours.length,
+        itemExtent: itemExtent,
         itemBuilder: (BuildContext context, int index) {
           final hour = hours[index];
 

--- a/lib/time_list.dart
+++ b/lib/time_list.dart
@@ -90,7 +90,6 @@ class _TimeListState extends State<TimeList> {
         scrollDirection: Axis.horizontal,
         padding: EdgeInsets.only(left: widget.padding),
         itemCount: hours.length,
-        itemExtent: itemExtent,
         itemBuilder: (BuildContext context, int index) {
           final hour = hours[index];
 
@@ -103,7 +102,7 @@ class _TimeListState extends State<TimeList> {
               activeBackgroundColor: widget.activeBackgroundColor,
               textStyle: widget.textStyle,
               activeTextStyle: widget.activeTextStyle,
-              time: hour.hhmm(),
+              time: hour.format(context),
               value: _selectedHour == hour,
               onSelect: (_) => _selectHour(index, hour),
             ),

--- a/lib/time_of_day_extension.dart
+++ b/lib/time_of_day_extension.dart
@@ -26,22 +26,4 @@ extension TimeOfDayExtension on TimeOfDay {
     final total = this.inMinutes() - minutes;
     return TimeOfDay(hour: total ~/ 60, minute: total % 60);
   }
-
-  static TimeOfDay fromString(String time) {
-    return TimeOfDay(
-        hour: int.parse(time.split(":")[0]),
-        minute: int.parse(time.split(":")[1]));
-  }
-
-  String hhmm() {
-    String _addLeadingZeroIfNeeded(int value) {
-      if (value < 10) return '0$value';
-      return value.toString();
-    }
-
-    final String hourLabel = _addLeadingZeroIfNeeded(hour);
-    final String minuteLabel = _addLeadingZeroIfNeeded(minute);
-
-    return '$hourLabel:$minuteLabel';
-  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: time_range
 description: Flutter widget for selecting a time range. You can specify the steps between the hours, time blocks that the range must meet and widget colors.
-version: 0.4.0
+version: 0.5.0
 homepage: https://github.com/ikicodedev/time_range.git
 
 environment:


### PR DESCRIPTION
TimeOfDay has a built in method `format(BuildContext context)` which will format the time in the devices default format based on the users locale and device settings. 
This PR switches to using the built in format method rather than the hard coded one that always used 24 hr time.