### PR TITLE
Avoid too large time steps in end time selection

### DIFF
--- a/lib/time_range.dart
+++ b/lib/time_range.dart
@@ -112,7 +112,7 @@ class _TimeRangeState extends State<TimeRange> {
               : _startHour.add(minutes: widget.timeBlock),
           lastTime: widget.lastTime,
           initialTime: _endHour,
-          timeStep: widget.timeBlock,
+          timeStep: widget.timeStep,
           padding: widget.titlePadding,
           onHourSelected: _endHourChanged,
           borderColor: widget.borderColor,
@@ -129,7 +129,10 @@ class _TimeRangeState extends State<TimeRange> {
   void _startHourChanged(TimeOfDay hour) {
     setState(() => _startHour = hour);
     if (_endHour != null) {
-      if(_endHour.inMinutes() <= _startHour.inMinutes() || (_endHour.inMinutes() - _startHour.inMinutes()).remainder(widget.timeBlock) != 0){
+      if (_endHour.inMinutes() <= _startHour.inMinutes() ||
+          (_endHour.inMinutes() - _startHour.inMinutes())
+                  .remainder(widget.timeBlock) !=
+              0) {
         _endHour = null;
         widget.onRangeCompleted(null);
       } else {


### PR DESCRIPTION
I am not sure if this is a expected behaviour or not.

In my current app i want to set a minimum rental period of 2 hours and if i set the timeBlock value to 120, the end time goes in 2 hour steps. I would expected it would take the timeStep value.

### State of master:
#### Code:
```
TimeRange(
...
timeStep: 60
timeBlock: 120
...
),
```
### Result:

Start:
6:00 | **7:00** | 8:00 | 9:00
End:
9:00 | 11:00 | 13:00 | 15:00
*_Bold start time is the selected time._

### Expected Result:

Start:
6:00 | **7:00** | 8:00 | 9:00
End:
9:00 | 10:00 | 11:00 | 12:00 | 13:00